### PR TITLE
adding home conda libs directory to `LD_LIBRARY_PATH` for run command

### DIFF
--- a/pinto/env.py
+++ b/pinto/env.py
@@ -327,14 +327,19 @@ class CondaEnvironment(Environment):
         return response
 
     def run(self, *args):
-        ld_lib_path = os.environ["LD_LIBRARY_PATH"]
-        prefix = os.environ["CONDA_PREFIX"]
-        os.environ["LD_LIBRARY_PATH"] = ld_lib_path + f":{prefix}/lib"
+        try:
+            ld_lib_path = os.environ["LD_LIBRARY_PATH"]
+        except KeyError:
+            ld_lib_path = None
+        else:
+            prefix = os.environ["CONDA_PREFIX"]
+            os.environ["LD_LIBRARY_PATH"] = ld_lib_path + f":{prefix}/lib"
 
         try:
             result = _run_conda_command(
                 conda.Commands.RUN, "-n", self.name, *args
             )
         finally:
-            os.environ["LD_LIBRARY_PATH"] = ld_lib_path
+            if ld_lib_path is not None:
+                os.environ["LD_LIBRARY_PATH"] = ld_lib_path
         return result

--- a/pinto/env.py
+++ b/pinto/env.py
@@ -327,4 +327,14 @@ class CondaEnvironment(Environment):
         return response
 
     def run(self, *args):
-        return _run_conda_command(conda.Commands.RUN, "-n", self.name, *args)
+        ld_lib_path = os.environ["LD_LIBRARY_PATH"]
+        prefix = os.environ["CONDA_PREFIX"]
+        os.environ["LD_LIBRARY_PATH"] = ld_lib_path + f":{prefix}/lib"
+
+        try:
+            result = _run_conda_command(
+                conda.Commands.RUN, "-n", self.name, *args
+            )
+        finally:
+            os.environ["LD_LIBRARY_PATH"] = ld_lib_path
+        return result


### PR DESCRIPTION
Addressing an issue where torch import can cause some libraries with C++ pointers (scipy, matplotlib, etc.) to miss these pointers.