### PR TITLE
Interaction and dotenv

### DIFF
--- a/examples/simple-poetry-example/poetry.lock
+++ b/examples/simple-poetry-example/poetry.lock
@@ -9,10 +9,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "*"
-content-hash = "242b994e47286b465d0046bb51c81bed4374654a6b352a00110ed62db62d8c62"
+content-hash = "ab6777d144fb815c824a394fdbb4df8008af75cd1b0b6a486e9eaf50e3fa32d6"
 
 [metadata.files]
-pip-install-test = [
-    {file = "pip-install-test-0.5.tar.gz", hash = "sha256:c33c46ced9865b59963e86e54901947520bdb73bf91849cddbb000742598bb67"},
-    {file = "pip_install_test-0.5-py3-none-any.whl", hash = "sha256:623887f5ce0b4695ec3c0503aa4f394253a403e2bb952417b3a778f0802dbe0b"},
-]
+pip-install-test = []

--- a/pinto/cli.py
+++ b/pinto/cli.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 from collections import OrderedDict
+from pathlib import Path
 from typing import List
 
 from pinto import __version__
@@ -69,6 +70,15 @@ class RunCommand(Command):
     """
 
     @classmethod
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "-e",
+            "--environment",
+            type=Path,
+            help="Path to file specifying environment variables for run",
+        )
+
+    @classmethod
     def run(cls, flags: argparse.Namespace, extra_args: List[str]) -> None:
         # first see if the project_path is to a single project
         try:
@@ -92,7 +102,7 @@ class RunCommand(Command):
                     )
 
                 # execute the pipeline
-                pipeline.run()
+                pipeline.run(env=flags.environment)
             else:
                 # otherwise this is some other KeyError, raise it
                 raise
@@ -103,7 +113,7 @@ class RunCommand(Command):
             if len(extra_args) == 0:
                 raise ValueError("Must provide a command to run!")
 
-            stdout = project.run(*extra_args)
+            stdout = project.run(*extra_args, env=flags.environment)
             logger.info(stdout)
 
 

--- a/pinto/cli.py
+++ b/pinto/cli.py
@@ -113,8 +113,7 @@ class RunCommand(Command):
             if len(extra_args) == 0:
                 raise ValueError("Must provide a command to run!")
 
-            stdout = project.run(*extra_args, env=flags.environment)
-            logger.info(stdout)
+            project.run(*extra_args, env=flags.environment)
 
 
 class BuildCommand(Command):

--- a/pinto/project.py
+++ b/pinto/project.py
@@ -246,7 +246,7 @@ class Pipeline(ProjectBase):
         # so that it won't attempt to load any local
         # environment file it might have
         method = project.load_dotenv
-        project.load_dotenv = lambda self, env: None
+        project.load_dotenv = lambda env: None
         try:
             project.run(command, "--typeo", typeo_arg)
         finally:

--- a/poetry.lock
+++ b/poetry.lock
@@ -373,6 +373,17 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "python-dotenv"
+version = "0.20.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2022.1"
 description = "World timezone definitions, modern and historical"
@@ -598,7 +609,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "eb5d8526166153678e50a17f6024e45d1d22fff15317113c1cabdaddb1fac22b"
+content-hash = "919e736c8c10db91d7fe39a4a374c99ceda9654d4550427d3fd5835dfecdae8a"
 
 [metadata.files]
 alabaster = [
@@ -770,6 +781,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.20.0.tar.gz", hash = "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f"},
+    {file = "python_dotenv-0.20.0-py3-none-any.whl", hash = "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"},
 ]
 pytz = [
     {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,6 +111,17 @@ docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=
 testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
+name = "hermes-typeo"
+version = "0.1.5"
+description = "Utilities for running functions as scripts"
+category = "main"
+optional = false
+python-versions = ">=3.8,<4.0"
+
+[package.dependencies]
+toml = ">=0.10.2,<0.11.0"
+
+[[package]]
 name = "identify"
 version = "2.4.12"
 description = "File identification library for Python"
@@ -609,7 +620,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "919e736c8c10db91d7fe39a4a374c99ceda9654d4550427d3fd5835dfecdae8a"
+content-hash = "30cf93666682626ddb4be7caccee3a00863e36d736ab1af4034f3ac212bf61ab"
 
 [metadata.files]
 alabaster = [
@@ -659,6 +670,10 @@ docutils = [
 filelock = [
     {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
     {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
+]
+hermes-typeo = [
+    {file = "hermes.typeo-0.1.5-py3-none-any.whl", hash = "sha256:a1fff2eeb257fb6f4f4b4b397681f2eddee59a4b8b3dd275f0fd9dac38e3371b"},
+    {file = "hermes.typeo-0.1.5.tar.gz", hash = "sha256:8bd1d97a698c0e99a7d2a6b3b082c8b8290aea1bf0e6a44548752ca178a8c73e"},
 ]
 identify = [
     {file = "identify-2.4.12-py2.py3-none-any.whl", hash = "sha256:5f06b14366bd1facb88b00540a1de05b69b310cbc2654db3c7e07fa3a4339323"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ pinto = "pinto.cli:main"
 [tool.poetry.dependencies]
 python = "^3.8,<3.10"
 toml = "^0.10"
+python-dotenv = "^0.20"
 
 [tool.poetry.group.dev.dependencies]
 pip = "^21.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ pinto = "pinto.cli:main"
 python = "^3.8,<3.10"
 toml = "^0.10"
 python-dotenv = "^0.20"
+"hermes.typeo" = "^0.1.5"
 
 [tool.poetry.group.dev.dependencies]
 pip = "^21.3"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,10 @@ def extras(request):
 
 @pytest.fixture
 def make_project_dir(conda_poetry_config):
-    def f(project_name, extras=None, conda=False):
+    def f(project_name, extras=None, conda=False, subdir=False):
         project_dir = Path(__file__).resolve().parent / "tmp"
+        if subdir:
+            project_dir /= project_name
 
         standardized_name = project_name.replace("-", "_")
         # TODO: fixture for python version?

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,48 +32,60 @@ def extras(request):
 
 
 @pytest.fixture
-def project_dir(project_name, extras):
-    project_dir = Path(__file__).resolve().parent / "tmp"
+def make_project_dir(conda_poetry_config):
+    def f(project_name, extras=None, conda=False):
+        project_dir = Path(__file__).resolve().parent / "tmp"
 
-    standardized_name = project_name.replace("-", "_")
-    # TODO: fixture for python version?
-    pyproject = {
-        "tool": {
-            "poetry": {
-                "name": project_name,
-                "version": "0.0.1",
-                "description": "test project",
-                "authors": ["test author <test@testproject.biz>"],
-                "scripts": {"testme": standardized_name + ":main"},
-                "dependencies": {
-                    "python": ">=3.9,<3.11",
-                    "pip_install_test": "^0.5",
-                },
+        standardized_name = project_name.replace("-", "_")
+        # TODO: fixture for python version?
+        pyproject = {
+            "tool": {
+                "poetry": {
+                    "name": project_name,
+                    "version": "0.0.1",
+                    "description": "test project",
+                    "authors": ["test author <test@testproject.biz>"],
+                    "scripts": {"testme": standardized_name + ":main"},
+                    "dependencies": {
+                        "python": ">=3.9,<3.11",
+                        "pip_install_test": "^0.5",
+                    },
+                }
             }
         }
-    }
-    if extras is not None:
-        pyproject["tool"]["poetry"]["dependencies"][extras] = {
-            "version": "^21.4",
-            "optional": True,
-        }
-        pyproject["tool"]["poetry"]["extras"] = {"extra": ["attrs"]}
+        if extras is not None:
+            pyproject["tool"]["poetry"]["dependencies"][extras] = {
+                "version": "^21.4",
+                "optional": True,
+            }
+            pyproject["tool"]["poetry"]["extras"] = {"extra": ["attrs"]}
 
-    os.makedirs(project_dir)
-    with open(project_dir / "pyproject.toml", "w") as f:
-        toml.dump(pyproject, f)
-    with open(project_dir / (standardized_name + ".py"), "w") as f:
-        f.write("def main():\n" "    print('can you hear me?')\n")
+        os.makedirs(project_dir)
+        with open(project_dir / "pyproject.toml", "w") as f:
+            toml.dump(pyproject, f)
+        with open(project_dir / (standardized_name + ".py"), "w") as f:
+            f.write("def main():\n" "    print('can you hear me?')\n")
 
+        if conda:
+            with open(project_dir / "poetry.toml", "w") as f:
+                toml.dump(conda_poetry_config, f)
+        return project_dir
+
+    return f
+
+
+@pytest.fixture
+def project_dir(make_project_dir, project_name, extras):
+    project_dir = make_project_dir(project_name, extras)
     yield project_dir
     shutil.rmtree(project_dir)
 
 
 @pytest.fixture
-def conda_project_dir(project_dir, conda_poetry_config):
-    with open(project_dir / "poetry.toml", "w") as f:
-        toml.dump(conda_poetry_config, f)
-    return project_dir
+def conda_project_dir(make_project_dir, project_name, extras):
+    project_dir = make_project_dir(project_name, extras, True)
+    yield project_dir
+    shutil.rmtree(project_dir)
 
 
 @pytest.fixture(params=["yaml", "yml"])
@@ -154,14 +166,6 @@ def _conda_env_context(env, nest):
                 pass
 
 
-@contextmanager
-def _poetry_env_context(env):
-    try:
-        yield
-    finally:
-        shutil.rmtree(env.env_root)
-
-
 @pytest.fixture
 def conda_env_context(nest):
     return partial(_conda_env_context, nest=nest)
@@ -169,25 +173,84 @@ def conda_env_context(nest):
 
 @pytest.fixture
 def poetry_env_context():
-    return _poetry_env_context
+    @contextmanager
+    def ctx(env):
+        try:
+            yield
+        finally:
+            shutil.rmtree(env.env_root)
+
+    return ctx
 
 
 @pytest.fixture
-def installed_project_tests(extras):
+def installed_project_tests(extras, capfd):
     def _test_installed_project(project):
         assert project._venv.exists()
         assert project._venv.contains(project)
 
-        output = project.run("testme")
-        assert output.rstrip() == "can you hear me?"
+        project.run("testme")
+        output = capfd.readouterr()
+        assert output.out.endswith("can you hear me?\n")
 
-        output = project.run("python", "-c", "import pip_install_test")
-        assert output.startswith("Good job!")
+        project.run("python", "-c", "import pip_install_test")
+        output = capfd.readouterr()
+        assert output.out.startswith("Good job!")
 
         if extras is not None:
             project.run("python", "-c", "import attrs")
         else:
-            with pytest.raises(Exception):
+            with pytest.raises(SystemExit):
                 project.run("python", "-c", "import attrs")
 
     return _test_installed_project
+
+
+@pytest.fixture(params=[None, ".env", ".other-env"], scope="function")
+def dotenv(request):
+    return request.param
+
+
+@pytest.fixture
+def validate_dotenv(dotenv, capfd):
+    def f(project):
+        script = """
+            import os
+            print(os.environ['ENVARG1'])
+            print(os.environ['ENVARG2'])
+        """
+        script = "\n".join([i.strip() for i in script.splitlines()])
+
+        if dotenv != ".env":
+            # if there's no .env, pinto won't know to look for one
+            # and so the environment variables should not get set
+            with pytest.raises(SystemExit):
+                project.run("python", "-c", script)
+            stderr = capfd.readouterr().err
+            assert "KeyError" in stderr
+
+            # if there is an env file, just not one called .env,
+            # we can specify explicitly via the `env` argument
+            if dotenv is not None:
+                env = str(project.path / dotenv)
+                project.run("python", "-c", script, env=env)
+                stdout = capfd.readouterr().out
+                assert stdout == "thom\nthom-yorke\n"
+        elif dotenv == ".env":
+            # if there is a .env file, we shouldn't need to
+            # specify anything: pinto will pick it up on its own
+            project.run("python", "-c", script)
+            stdout = capfd.readouterr().out
+            assert stdout.endswith("thom\nthom-yorke\n")
+
+    return f
+
+
+@pytest.fixture
+def write_dotenv(dotenv):
+    def f(project_dir):
+        if dotenv is not None:
+            with open(project_dir / dotenv, "w") as f:
+                f.write("ENVARG1=thom\nENVARG2=${ENVARG1}-yorke\n")
+
+    return f

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 
 import pytest
@@ -86,3 +87,41 @@ def test_cli_run_poetry(project_dir, project_flag, poetry_env_context):
         if project._venv.exists():
             with poetry_env_context(project._venv):
                 pass
+
+
+def test_cli_run_with_dotenv(
+    make_project_dir, poetry_env_context, write_dotenv, dotenv
+):
+    project_dir = make_project_dir("testlib", None, False)
+    write_dotenv(project_dir)
+
+    py_cmd = (
+        "import os;print(os.environ['ENVARG1']);print(os.environ['ENVARG2'])"
+    )
+    py_cmd = f'"{py_cmd}"'
+    pinto_cmd = f"pinto -v -p {project_dir} run"
+
+    try:
+        if dotenv != ".env":
+            # if there's no .env, pinto won't know to look for one
+            # and so the environment variables should not get set
+            cmd = f"{pinto_cmd} python -c {py_cmd}"
+            with pytest.raises(RuntimeError) as exc_info:
+                run_command(cmd)
+            assert "KeyError" in str(exc_info.value)
+
+            # if there is an env file, just not one called .env,
+            # we can specify explicitly via the `env` argument
+            if dotenv is not None:
+                env = project_dir / dotenv
+                cmd = f"{pinto_cmd} -e {env} python -c {py_cmd}"
+                output = run_command(cmd)
+                assert output.endswith("thom\nthom-yorke\n")
+        else:
+            # if there is a .env file, we shouldn't need to
+            # specify anything: pinto will pick it up on its own
+            cmd = f"{pinto_cmd} python -c {py_cmd}"
+            output = run_command(cmd)
+            assert output.endswith("thom\nthom-yorke\n")
+    finally:
+        shutil.rmtree(project_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,4 +124,9 @@ def test_cli_run_with_dotenv(
             output = run_command(cmd)
             assert output.endswith("thom\nthom-yorke\n")
     finally:
+        project = Project(project_dir)
+        if project._venv.exists():
+            with poetry_env_context(project._venv):
+                pass
+
         shutil.rmtree(project_dir)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -45,7 +45,7 @@ def conda_project_with_no_environment(conda_project_dir, project_name):
 
 @pytest.fixture
 def test_installed_env(extras, capfd):
-    def _test_installed_env(env, project):
+    def f(env, project):
         """Test an environment that has ostensibly installed its project"""
 
         # make sure that the `contains` method correctly
@@ -54,25 +54,29 @@ def test_installed_env(extras, capfd):
 
         # make sure we can run our `testme` script
         # and that it produces the appropriate output
-        output = env.run("testme")
-        assert output.rstrip() == "can you hear me?"
+        env.run("testme")
+        output = capfd.readouterr().out
+        assert output == "can you hear me?\n"
 
         # now make sure that our dependency
         # got installed correctly
-        output = env.run("python", "-c", "import pip_install_test")
+        env.run("python", "-c", "import pip_install_test")
+        output = capfd.readouterr().out
         assert output.startswith("Good job!")
 
         if extras is not None:
-            output = env.run("python", "-c", "import attrs")
+            env.run("python", "-c", "import attrs")
         else:
-            with pytest.raises(Exception):
+            with pytest.raises(SystemExit):
                 env.run("python", "-c", "import attrs")
+            stderr = capfd.readouterr().err
+            assert "ModuleNotFoundError" in stderr
 
-    return _test_installed_env
+    return f
 
 
 def test_poetry_environment(
-    poetry_project, poetry_env_context, extras, test_installed_env
+    poetry_project, poetry_env_context, extras, test_installed_env, capfd
 ):
     # make sure that the __new__ method maps correctly from
     # a project with no "poetry.toml" to a PoetryEnvironment
@@ -108,6 +112,7 @@ def test_poetry_environment(
         else:
             env.install(extras=["extra"])
 
+        capfd.readouterr()  # clear the stdout buffer
         test_installed_env(env, poetry_project)
 
 
@@ -118,6 +123,7 @@ def test_conda_environment(
     conda_env_context,
     extras,
     test_installed_env,
+    capfd,
 ):
     # make sure that the __new__ method maps correctly from
     # a project with a "poetry.toml" to a CondaEnvironment
@@ -146,7 +152,7 @@ def test_conda_environment(
     assert env.path == expected_path
     assert not env.exists()
     assert env.name == expected_name
-    assert env._base_env == expected_env
+    assert env.base_env == expected_env
 
     # now create the environment, then run all
     # the tests in a context so that it gets
@@ -162,8 +168,9 @@ def test_conda_environment(
         # make sure that we can import the dependency
         # listed in our _conda_ environment file, and
         # that the `run` method works properly
-        output = env.run("python", "-c", "import requests;print('got it!')")
-        assert output.rstrip() == "got it!"
+        env.run("python", "-c", "import requests;print('got it!')")
+        output = capfd.readouterr().out
+        assert output == "got it!\n"
 
         # now install the test package and run the
         # standard tests on it
@@ -171,6 +178,8 @@ def test_conda_environment(
             env.install()
         else:
             env.install(extras=["extra"])
+
+        capfd.readouterr()  # clear the stdout buffer
         test_installed_env(env, conda_project)
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -44,7 +44,7 @@ def conda_project_with_no_environment(conda_project_dir, project_name):
 
 
 @pytest.fixture
-def test_installed_env(extras):
+def test_installed_env(extras, capfd):
     def _test_installed_env(env, project):
         """Test an environment that has ostensibly installed its project"""
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,9 @@
+import os
+import shutil
+
 import pytest
 import toml
+import yaml
 
 from pinto.env import CondaEnvironment, PoetryEnvironment
 from pinto.project import Project
@@ -35,6 +39,7 @@ def test_conda_project(
     conda_env_context,
     installed_project_tests,
     extras,
+    capfd,
 ):
     project = Project(complete_conda_project_dir)
     assert isinstance(project._venv, CondaEnvironment)
@@ -53,9 +58,53 @@ def test_conda_project(
         project.install(extras=["extra"])
 
     with conda_env_context(project._venv):
-        output = project.run(
-            "python", "-c", "import requests;print('got it!')"
-        )
-        assert output.rstrip() == "got it!"
+        project.run("python", "-c", "import requests;print('passed!')")
+        output = capfd.readouterr().out
+        assert output.splitlines()[-1] == "passed!"
 
         installed_project_tests(project)
+
+
+@pytest.fixture(scope="function")
+def poetry_dotenv_project_dir(make_project_dir, write_dotenv, dotenv):
+    project_dir = make_project_dir("testlib", None, False)
+    write_dotenv(project_dir)
+
+    yield project_dir
+    shutil.rmtree(project_dir)
+    if dotenv is not None:
+        os.environ.pop("ENVARG1")
+        os.environ.pop("ENVARG2")
+
+
+@pytest.fixture(scope="function")
+def conda_dotenv_project_dir(
+    make_project_dir, write_dotenv, conda_environment_dict, dotenv
+):
+    project_dir = make_project_dir("testlib", None, True)
+    with open(project_dir / "environment.yaml", "w") as f:
+        yaml.dump(conda_environment_dict, f)
+    write_dotenv(project_dir)
+
+    yield project_dir
+    shutil.rmtree(project_dir)
+    if dotenv is not None:
+        os.environ.pop("ENVARG1")
+        os.environ.pop("ENVARG2")
+
+
+def test_poetry_project_with_dotenv(
+    poetry_dotenv_project_dir, poetry_env_context, dotenv, validate_dotenv
+):
+    project = Project(poetry_dotenv_project_dir)
+    with poetry_env_context(project.venv):
+        project.install()
+        validate_dotenv(project)
+
+
+def test_conda_project_with_dotenv(
+    conda_dotenv_project_dir, dotenv, validate_dotenv
+):
+    project = Project(conda_dotenv_project_dir)
+    project.install()
+    validate_dotenv(project)


### PR DESCRIPTION
- Updating `run` implementation on `Environment` subclasses to support interactive execution
- Adding `.env` file support for project and pipeline execution (closes #23 )
- Cleaning up and modularizing Conda environment file search

`.env` support works in the following way:
1. An explicit path to an environment variable file can be specified at the command line via the `-e/--environment` flag. If the specified path is not absolute, it will be taken to be relative to the project or pipeline root directory.
2. If a path is not passed to `-e/--environment`, `pinto` will look to see if a `.env` file exists in the project or pipeline root directory and load it by default.
3. If a pipeline is being executed, individual project `.env` files will be ignored
4. The environment variable file parsing is handled by `python-dotenv` under the hood, and so inherits all of its functionality (in particular the ability to refer to other environment variables in a new environment variable's definition).

Implementation questions:
- For point (2) above, should this be the default behavior? Alternatively, I can imagine adding a `--no-env` flag that turns off this default behavior. My thinking is that if you really don't want to use a local environment variable file, you can always just change its name away from `.env` since it shouldn't be tracked by Git anyway. Presumably, if you're using the name `.env` for the file, it should be sufficiently standard/general that you'll want to use it all the time. The worst case is that you can just refer only to existing environment variables in it, in which case you'd recover the existing functionality.
- For point (3), is this sensible behavior? I think so, since there would be no way to specify to the pipeline which environment variable files to pull from each project, and so the naive strategy of just using each of their `.env`s could get messy. This also helps to keep pipeline execution grouped and centralized in one place, separate from the individual projects it contains. The one benefit here would be that we could set `LD_LIBRARY_PATH` in project `.env`s individually and therefore subsume the behavior desired by #20 , but this feature is probably worth implementing on its own and should be tracked with the rest of the files in Git (i.e. not contained in a local `.env` file, since presumably the CUDA version should be pinned to the project).

TODOs:
- [x] Tests for pipelines (both in general and with `.env` support)