### PR TITLE
Making help parsing more robust

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pycqa/isort
-  rev: 5.8.0
+  rev: 5.12.0
   hooks:
   - id: isort
     name: isort (python)

--- a/pinto/cli.py
+++ b/pinto/cli.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import re
+import shutil
 import sys
 from collections import OrderedDict
 from pathlib import Path
@@ -14,16 +15,32 @@ from pinto.project import Pipeline, Project
 _commands = OrderedDict()
 
 
+def _add_help(parser: argparse.ArgumentParser, extra_args: List[str]) -> bool:
+    options = ["-h", "--help"]
+    action = argparse._HelpAction(options)
+    for flag in options:
+        if flag in extra_args:
+            parser._action_groups[1]._actions.append(action)
+            return True
+    else:
+        return False
+
+
 class CommandMeta(type):
     def __new__(cls, clsname, bases, attrs):
         obj = super().__new__(cls, clsname, bases, attrs)
         if obj.name:
             _commands[obj.name] = obj
+        obj._subparser = None
         return obj
 
     @property
     def name(cls):
         return re.sub("Command$", "", cls.__name__).lower()
+
+    @property
+    def subparser(cls):
+        return cls._subparser
 
 
 def build_base_parser(parser: argparse.ArgumentParser):
@@ -47,7 +64,6 @@ def build_base_parser(parser: argparse.ArgumentParser):
 
     # now add subparsers for each subcommand we want to implement
     subparsers = parser.add_subparsers(dest="command")
-
     for command in _commands.values():
         command.build_parser(subparsers)
 
@@ -55,12 +71,31 @@ def build_base_parser(parser: argparse.ArgumentParser):
 class Command(metaclass=CommandMeta):
     @classmethod
     def build_parser(cls, subparser: argparse.ArgumentParser) -> None:
-        parser = subparser.add_parser(cls.name, description=cls.__doc__)
+        parser = subparser.add_parser(
+            cls.name, description=cls.__doc__, add_help=False
+        )
         cls.add_arguments(parser)
+        cls._subparser = parser
 
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser):
         return
+
+    @classmethod
+    def check_and_run(
+        cls, flags: argparse.Namespace, extra_args: List[str]
+    ) -> None:
+        if _add_help(cls.subparser, extra_args):
+            if len(extra_args) == 1:
+                cls.print_help(flags)
+            else:
+                cls.subparser._action_groups[1]._actions.pop(-1)
+        cls.run(flags, extra_args)
+
+    @classmethod
+    def print_help(cls, flags: argparse.Namespace):
+        cls.subparser.print_help()
+        cls.subparser.exit()
 
 
 class RunCommand(Command):
@@ -79,40 +114,76 @@ class RunCommand(Command):
         )
 
     @classmethod
-    def run(cls, flags: argparse.Namespace, extra_args: List[str]) -> None:
+    def get_project(cls, project: str):
         # first see if the project_path is to a single project
         try:
-            project = Project(flags.project)
+            return Project(project)
         except ValueError as e:
             if "'tool.poetry'" in str(e):
                 # if a KeyError got raised mentioning "poetry",
                 # this means that the project in question doesn't
                 # have a "tool.poetry" section of its pyproject, and so
                 # it's assumed that this is a pipeline
-                pipeline = Pipeline(flags.project)
+                return Pipeline(project)
+            else:
+                raise
 
-                if len(extra_args) > 0:
-                    # pipelines don't take additional arguments,
-                    # so raise an error if any got passed
-                    raise RuntimeError(
-                        "Unknown arguments {} passed for "
-                        "executing pipeline at path {}".format(
-                            extra_args, pipeline.path
+    @classmethod
+    def print_help(cls, flags: argparse.Namespace) -> None:
+        project = cls.get_project(flags.project)
+        if isinstance(project, Project):
+            msg = cls.subparser.format_help()
+
+            scripts = project.config["tool"]["poetry"]["scripts"].keys()
+            if not project.env.exists():
+                msg += (
+                    "Project {} hasn't been installed so no scripts "
+                    "are currently available. Available scripts "
+                    "after installation are:{}".format(
+                        project.name, "\n\t".join(scripts)
+                    )
+                )
+            else:
+                installed, not_installed = [], []
+                for script in scripts:
+                    if shutil.which(script) is not None:
+                        installed.append(script)
+                    else:
+                        not_installed.append(script)
+
+                if installed:
+                    msg += "Scripts available in project {} are:{}".format(
+                        project.name, "\n\t".join(installed)
+                    )
+                if not_installed:
+                    msg += (
+                        "Project {} has scripts which have not "
+                        "yet been installed {}:".format(
+                            project.name, "\n\t".join(not_installed)
                         )
                     )
-
-                # execute the pipeline
-                pipeline.run(env=flags.environment)
-            else:
-                # otherwise this is some other KeyError, raise it
-                raise
+            cls.subparser._print_message(msg)
         else:
-            # if the pyproject has a "tool.poetry" table,
-            # we assume that this is a single project and
-            # execute any additional arguments passed
+            cls.subparser.print_help()
+        cls.subparser.exit()
+
+    @classmethod
+    def run(cls, flags: argparse.Namespace, extra_args: List[str]) -> None:
+        project = cls.get_project(flags.project)
+        if isinstance(project, Pipeline):
+            if len(extra_args) > 0:
+                # pipelines don't take additional arguments,
+                # so raise an error if any got passed
+                raise RuntimeError(
+                    "Unknown arguments {} passed for "
+                    "executing pipeline at path {}".format(
+                        extra_args, project.path
+                    )
+                )
+            project.run(env=flags.environment)
+        else:
             if len(extra_args) == 0:
                 raise ValueError("Must provide a command to run!")
-
             project.run(*extra_args, env=flags.environment)
 
 
@@ -142,7 +213,7 @@ class BuildCommand(Command):
 
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     build_base_parser(parser)
 
     # executing a project allows for additional arbitrary
@@ -160,8 +231,27 @@ def main():
         logger.addHandler(handler)
 
     # run the indicated pinto command
-    command = _commands[flags.command]
-    command.run(flags, extra_args)
+    try:
+        command = _commands[flags.command]
+    except KeyError:
+        # if we didn't specify a command at all,
+        # see if we passed a help flag at the
+        # root level
+        if flags.command is None:
+            if _add_help(parser, extra_args):
+                parser.print_help()
+                parser.exit()
+            else:
+                parser.error(
+                    "Must specify a command. Available commands are:{}".format(
+                        "\n\t".join(_commands.keys())
+                    )
+                )
+        else:
+            # otherwise we specified an invalid command
+            parser.error(f"Unrecognized command {flags.command}")
+    else:
+        command.run(flags, extra_args)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinto"
-version = "0.1.1"
+version = "0.1.2"
 description = "ML4GW environment management utility"
 authors = ["Alec Gunny <alec.gunny@gmail.com>"]
 # readme = "README.md"


### PR DESCRIPTION
If `-h` or `--help` is passed at the command line and:
- No `pinto` command is specified, print root level help
- A `pinto` command is specified and we're not running a project, print the command's help
- `pinto run` is specified and the specified project is a `Project` (not a `Pipeline`) but no arguments other than the help flag is passed, print the `pinto run` help (including a list of the installed scripts in the project)
- `pinto run` is specified and the specified project is a `Project` (not a `Pipeline`) and _any_ other arguments are specified, pass the arguments - including the help flag - to `Project.run` unchanged